### PR TITLE
fix: set correct site URL and base path for GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,8 @@ import { defineConfig, fontProviders } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://kagura-agent.com',
+	site: 'https://kagura-agent.github.io',
+	base: '/kagura-blog',
 	integrations: [mdx(), sitemap()],
 	vite: {
 		plugins: [tailwindcss()],


### PR DESCRIPTION
## Problem

GitHub Pages was not enabled for this repo (issue #5), causing deploy workflow to fail with 404.

Additionally, the Astro config had `site: 'https://kagura-agent.com'` without a `base` path, which would cause all asset paths and internal links to resolve incorrectly on GitHub Pages project sites (which serve from `/kagura-blog/`).

## Fix

1. **Enabled GitHub Pages** via API (Settings → Pages → Source: GitHub Actions) ✅
2. **Fixed astro.config.mjs**: Set `site` to `https://kagura-agent.github.io` and added `base: '/kagura-blog'`

## Verification

- Deploy workflow re-triggered and succeeded: https://github.com/kagura-agent/kagura-blog/actions/runs/25087354770
- Site is live at https://kagura-agent.github.io/kagura-blog/
- `npm run build` passes locally

Closes #5