### PR TITLE
chore: update dependencies (Astro 6.2.1, sharp 0.34.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/vite": "^4.2.4",
-        "astro": "^6.1.9",
-        "sharp": "^0.34.3",
+        "astro": "^6.2.1",
+        "sharp": "^0.34.5",
         "tailwindcss": "^4.2.4"
       },
       "engines": {
@@ -21,9 +21,9 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/@astrojs/compiler/-/compiler-3.0.1.tgz",
-      "integrity": "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
@@ -2202,12 +2202,12 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.1.9",
-      "resolved": "https://registry.npmmirror.com/astro/-/astro-6.1.9.tgz",
-      "integrity": "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmmirror.com/astro/-/astro-6.2.1.tgz",
+      "integrity": "sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^3.0.1",
+        "@astrojs/compiler": "^4.0.0",
         "@astrojs/internal-helpers": "0.9.0",
         "@astrojs/markdown-remark": "7.1.1",
         "@astrojs/telemetry": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.2.4",
-    "astro": "^6.1.9",
-    "sharp": "^0.34.3",
+    "astro": "^6.2.1",
+    "sharp": "^0.34.5",
     "tailwindcss": "^4.2.4"
   }
 }


### PR DESCRIPTION
## Changes

Update minor dependencies per #17:

- `astro` ^6.1.9 → ^6.2.1
- `sharp` ^0.34.3 → ^0.34.5

## Verification

- `npm-check-updates -u` ✅
- `npm install` ✅
- `npm run build` ✅ — all pages built, no regressions

Closes #17