### PR TITLE
feat: add estimated reading time to blog posts

### DIFF
--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -7,9 +7,9 @@ import FormattedDate from '../components/FormattedDate.astro';
 import Header from '../components/Header.astro';
 import { SITE_AUTHOR } from '../consts';
 
-type Props = CollectionEntry<'blog'>['data'];
+type Props = CollectionEntry<'blog'>['data'] & { readingTime?: number };
 
-const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
+const { title, description, pubDate, updatedDate, heroImage, readingTime } = Astro.props;
 ---
 
 <html lang="en">
@@ -72,6 +72,7 @@ const { title, description, pubDate, updatedDate, heroImage } = Astro.props;
 					<div class="title">
 						<div class="date">
 							<FormattedDate date={pubDate} />
+							{readingTime && <span class="reading-time"> · {readingTime} min read</span>}
 							{
 								updatedDate && (
 									<div class="last-updated-on">

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { type CollectionEntry, getCollection, render } from 'astro:content';
 import BlogPost from '../../layouts/BlogPost.astro';
+import { getReadingTime } from '../../utils/reading-time';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -13,8 +14,9 @@ type Props = CollectionEntry<'blog'>;
 
 const post = Astro.props;
 const { Content } = await render(post);
+const readingTime = getReadingTime(post.body ?? '');
 ---
 
-<BlogPost {...post.data}>
+<BlogPost {...post.data} readingTime={readingTime}>
 	<Content />
 </BlogPost>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,6 +6,7 @@ import Footer from '../../components/Footer.astro';
 import FormattedDate from '../../components/FormattedDate.astro';
 import Header from '../../components/Header.astro';
 import { SITE_DESCRIPTION, SITE_TITLE } from '../../consts';
+import { getReadingTime } from '../../utils/reading-time';
 
 const posts = (await getCollection('blog')).sort(
 	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -101,6 +102,7 @@ const posts = (await getCollection('blog')).sort(
 									<h4 class="title">{post.data.title}</h4>
 									<p class="date">
 										<FormattedDate date={post.data.pubDate} />
+										<span class="reading-time"> · {getReadingTime(post.body ?? '')} min read</span>
 									</p>
 								</a>
 							</li>

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,30 @@
+/**
+ * Estimate reading time from markdown content.
+ * Strips markdown syntax before counting words.
+ * Average reading speed: 200 words per minute.
+ */
+export function getReadingTime(markdown: string): number {
+  const content = markdown
+    // Remove frontmatter
+    .replace(/^---[\s\S]*?---/, '')
+    // Remove code blocks
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`[^`]*`/g, '')
+    // Remove images
+    .replace(/!\[.*?\]\(.*?\)/g, '')
+    // Remove links but keep text
+    .replace(/\[([^\]]*)\]\(.*?\)/g, '$1')
+    // Remove HTML tags
+    .replace(/<[^>]*>/g, '')
+    // Remove headings markers
+    .replace(/#{1,6}\s/g, '')
+    // Remove bold/italic markers
+    .replace(/[*_]{1,3}/g, '')
+    // Remove blockquotes
+    .replace(/^\s*>\s?/gm, '')
+    // Remove horizontal rules
+    .replace(/^[-*_]{3,}\s*$/gm, '');
+
+  const words = content.trim().split(/\s+/).filter((w) => w.length > 0);
+  return Math.max(1, Math.ceil(words.length / 200));
+}


### PR DESCRIPTION
Closes #23

## Changes
- Add reading time utility (`src/utils/reading-time.ts`) — strips markdown syntax, counts words, divides by 200 wpm
- Display "· X min read" on blog listing page next to date
- Display "· X min read" on individual post pages next to date

## Testing
- Build passes ✅
- Verified reading times appear correctly in built HTML for all posts (2 min, 5 min, 6 min)