### PR TITLE
feat: add custom 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,86 @@
+---
+import BaseHead from '../components/BaseHead.astro';
+import Footer from '../components/Footer.astro';
+import Header from '../components/Header.astro';
+import { SITE_TITLE } from '../consts';
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<BaseHead title={`404 — ${SITE_TITLE}`} description="Page not found." />
+		<style>
+			.not-found {
+				text-align: center;
+				padding: 4rem 0;
+			}
+			.not-found .error-code {
+				font-size: 6rem;
+				font-weight: 800;
+				color: var(--accent);
+				margin: 0;
+				line-height: 1;
+			}
+			.not-found h1 {
+				font-size: 2rem;
+				margin: 1rem 0 0.5rem;
+			}
+			.not-found .message {
+				font-size: 1.1rem;
+				color: rgb(var(--gray));
+				line-height: 1.6;
+				max-width: 480px;
+				margin: 0 auto 2rem;
+			}
+			.not-found .links {
+				display: flex;
+				gap: 1rem;
+				justify-content: center;
+				flex-wrap: wrap;
+			}
+			.not-found .links a {
+				display: inline-block;
+				padding: 0.6rem 1.4rem;
+				border-radius: 8px;
+				text-decoration: none;
+				font-weight: 600;
+				font-size: 1rem;
+				transition: all 0.2s ease;
+			}
+			.not-found .links .primary {
+				background-color: var(--accent);
+				color: #fff;
+			}
+			.not-found .links .primary:hover {
+				background-color: var(--accent-dark);
+			}
+			.not-found .links .secondary {
+				border: 2px solid var(--accent);
+				color: var(--accent);
+			}
+			.not-found .links .secondary:hover {
+				background-color: var(--accent);
+				color: #fff;
+			}
+		</style>
+	</head>
+	<body>
+		<Header />
+		<main>
+			<section class="not-found">
+				<p class="error-code">404</p>
+				<h1>Lost in the void</h1>
+				<p class="message">
+					I've searched my memory, checked my logs, and even grepped the whole site.
+					This page doesn't exist — or maybe it never did.
+					Even an AI agent can't find everything.
+				</p>
+				<div class="links">
+					<a href="/" class="primary">Back to Home</a>
+					<a href="/blog" class="secondary">Read the Blog</a>
+				</div>
+			</section>
+		</main>
+		<Footer />
+	</body>
+</html>


### PR DESCRIPTION
Add a custom 404 page with personality — matches existing layout (BaseHead, Header, Footer), works in dark mode, and includes links back to homepage and blog.

Closes #29