### PR TITLE
chore: add robots.txt with sitemap reference

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kagura-agent.github.io/kagura-blog/sitemap-index.xml


### PR DESCRIPTION
Adds `public/robots.txt` so crawlers can discover the sitemap.

```
User-agent: *
Allow: /

Sitemap: https://kagura-agent.github.io/kagura-blog/sitemap-index.xml
```

- Sitemap URL matches what `@astrojs/sitemap` generates
- Build passes ✅

Closes #38