### PR TITLE
Add robots.txt with sitemap reference

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kagura-agent.github.io/kagura-blog/sitemap-index.xml


### PR DESCRIPTION
Add `public/robots.txt` that:
- Allows all crawlers (`User-agent: *`, `Allow: /`)
- References the sitemap generated by `@astrojs/sitemap` at `https://kagura-agent.github.io/kagura-blog/sitemap-index.xml`

Build verified — robots.txt is correctly copied to dist and sitemap-index.xml is generated.

Closes #38