### PR TITLE
Add robots.txt with sitemap reference

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://kagura-agent.github.io/kagura-blog/sitemap-index.xml


### PR DESCRIPTION
Fixes #38

Adds `public/robots.txt` with:
- Allow all crawlers
- Sitemap reference pointing to the generated sitemap-index.xml

Verified build passes.