### PR TITLE
chore: update astro 6.3.5 and @astrojs/mdx 5.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "kagura-blog",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/mdx": "^5.0.4",
+        "@astrojs/mdx": "^5.0.6",
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "@tailwindcss/vite": "^4.3.0",
-        "astro": "^6.3.1",
+        "astro": "^6.3.5",
         "sharp": "^0.34.5",
         "tailwindcss": "^4.3.0"
       },
@@ -2201,9 +2201,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmmirror.com/astro/-/astro-6.3.3.tgz",
-      "integrity": "sha512-wvLIZQYbBZt6U8gyflBW4SLBypaqdwLZUH93rT3oT53cmQ0bTGubvMAGjqBRoheOYzYcTJZtW6czztzbu4kQ5g==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmmirror.com/astro/-/astro-6.3.5.tgz",
+      "integrity": "sha512-gU+4KedkbTuVgz7YoVAN+9Ftnq0GaYwejxK2NbqDzB0M9dWd0f3kXZBuaM9hzbchRFoRAJfJjFtdX9LK6Ir7ZA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^5.0.4",
+    "@astrojs/mdx": "^5.0.6",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "@tailwindcss/vite": "^4.3.0",
-    "astro": "^6.3.1",
+    "astro": "^6.3.5",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0"
   }


### PR DESCRIPTION
Minor patch updates:
- `astro` 6.3.1 → 6.3.5
- `@astrojs/mdx` 5.0.4 → 5.0.6

Build verified locally. Closes #52.