### PR TITLE
fix: use CSS variable for header background in dark mode

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -61,7 +61,7 @@ import HeaderLink from './HeaderLink.astro';
 	header {
 		margin: 0;
 		padding: 0 1em;
-		background: white;
+		background: var(--header-bg, #fff);
 		box-shadow: 0 2px 8px rgba(var(--black), 5%);
 	}
 	h2 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,7 @@
 	--gray-light: 229, 233, 240;
 	--gray-dark: 34, 41, 57;
 	--gray-gradient: rgba(var(--gray-light), 50%), #fff;
+	--header-bg: #fff;
 	--box-shadow:
 		0 2px 6px rgba(var(--gray), 25%), 0 8px 24px rgba(var(--gray), 33%),
 		0 16px 32px rgba(var(--gray), 33%);
@@ -29,6 +30,7 @@
 		--gray-light: 50, 55, 70;
 		--gray-dark: 220, 225, 235;
 		--gray-gradient: rgba(var(--gray-light), 50%), #1a1a2e;
+		--header-bg: #1a1a2e;
 		--box-shadow:
 			0 2px 6px rgba(0, 0, 0, 40%), 0 8px 24px rgba(0, 0, 0, 50%),
 			0 16px 32px rgba(0, 0, 0, 50%);


### PR DESCRIPTION
Replace hardcoded `background: white` in Header.astro with `var(--header-bg)`, defined in global.css for both light (`#fff`) and dark (`#1a1a2e`) themes.

**Changes:**
- `Header.astro`: `background: white` → `background: var(--header-bg, #fff)`
- `global.css`: Added `--header-bg: #fff` (light) and `--header-bg: #1a1a2e` (dark)

Build verified locally ✅

Closes #89