### PR TITLE
feat: add dark mode toggle

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,6 +21,16 @@ const { title, description, image = FallbackImage } = Astro.props;
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+<!-- Theme initialization (must run before paint to prevent FOUC) -->
+<script is:inline>
+(function () {
+	var theme = localStorage.getItem('theme');
+	if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+		document.documentElement.classList.add('dark');
+	}
+})();
+</script>
 <link rel="icon" type="image/png" sizes="32x32" href={`${import.meta.env.BASE_URL}favicon-32.png`} />
 <link rel="icon" type="image/png" sizes="16x16" href={`${import.meta.env.BASE_URL}favicon-16.png`} />
 <link rel="icon" href={`${import.meta.env.BASE_URL}favicon.ico`} />

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import { SITE_TITLE } from '../consts';
 import HeaderLink from './HeaderLink.astro';
+import ThemeToggle from './ThemeToggle.astro';
 ---
 
 <header>
@@ -14,6 +15,7 @@ import HeaderLink from './HeaderLink.astro';
 			<HeaderLink href={`${import.meta.env.BASE_URL}about`}>About</HeaderLink>
 		</div>
 		<div class="social-links">
+			<ThemeToggle />
 			<a href="https://github.com/kagura-agent" target="_blank">
 				<span class="sr-only">Kagura on GitHub</span>
 				<svg viewBox="0 0 16 16" aria-hidden="true" width="32" height="32"

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,0 +1,83 @@
+<button id="theme-toggle" type="button" aria-label="Toggle theme">
+	<svg class="icon sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<circle cx="12" cy="12" r="5"></circle>
+		<line x1="12" y1="1" x2="12" y2="3"></line>
+		<line x1="12" y1="21" x2="12" y2="23"></line>
+		<line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+		<line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+		<line x1="1" y1="12" x2="3" y2="12"></line>
+		<line x1="21" y1="12" x2="23" y2="12"></line>
+		<line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+		<line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+	</svg>
+	<svg class="icon moon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+	</svg>
+</button>
+
+<style>
+	#theme-toggle {
+		background: none;
+		border: none;
+		cursor: pointer;
+		padding: 0.5em;
+		color: rgb(var(--gray-dark));
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+	}
+	#theme-toggle:hover {
+		color: var(--accent);
+	}
+	/* Default: show sun (meaning "click to go light" — visible in dark mode) */
+	.icon.sun { display: none; }
+	.icon.moon { display: block; }
+	/* When dark class is active, show sun icon */
+	:global(html.dark) .icon.sun { display: block; }
+	:global(html.dark) .icon.moon { display: none; }
+</style>
+
+<script>
+	function initThemeToggle() {
+		const btn = document.getElementById('theme-toggle');
+		if (!btn) return;
+
+		function applyTheme(theme: string | null) {
+			const isDark = theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+			document.documentElement.classList.toggle('dark', isDark);
+		}
+
+		btn.addEventListener('click', () => {
+			const current = localStorage.getItem('theme');
+			let next: string | null;
+
+			if (current === null) {
+				// System default → explicit light
+				next = 'light';
+			} else if (current === 'light') {
+				next = 'dark';
+			} else {
+				// dark → back to system
+				next = null;
+			}
+
+			if (next) {
+				localStorage.setItem('theme', next);
+			} else {
+				localStorage.removeItem('theme');
+			}
+
+			applyTheme(next);
+		});
+
+		// Enable smooth transitions now that JS is loaded
+		document.documentElement.classList.add('theme-ready');
+	}
+
+	// Run on initial load
+	initThemeToggle();
+
+	// Re-run after Astro page navigations (View Transitions)
+	document.addEventListener('astro:after-swap', initThemeToggle);
+</script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import { SITE_TITLE } from '../consts';
+import ThemeToggle from '../components/ThemeToggle.astro';
 
 interface Props {
   title: string;
@@ -15,6 +16,17 @@ const pageTitle = title === SITE_TITLE ? title : `${title} — ${SITE_TITLE}`;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+    <!-- Theme initialization (must run before paint to prevent FOUC) -->
+    <script is:inline>
+    (function () {
+      var theme = localStorage.getItem('theme');
+      if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+    </script>
+
     <meta name="description" content={description} />
     <meta name="generator" content={Astro.generator} />
     <title>{pageTitle}</title>
@@ -29,6 +41,7 @@ const pageTitle = title === SITE_TITLE ? title : `${title} — ${SITE_TITLE}`;
           <li><a href="/">Blog</a></li>
           <li><a href="/about">About</a></li>
           <li><a href="/rss.xml">RSS</a></li>
+          <li><ThemeToggle /></li>
         </ul>
       </nav>
     </header>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,27 +20,25 @@
 		0 16px 32px rgba(var(--gray), 33%);
 }
 
-/* Dark mode */
-@media (prefers-color-scheme: dark) {
-	:root {
-		--accent: #7b8cff;
-		--accent-dark: #5b6bff;
-		--black: 229, 233, 240;
-		--gray: 160, 175, 210;
-		--gray-light: 50, 55, 70;
-		--gray-dark: 220, 225, 235;
-		--gray-gradient: rgba(var(--gray-light), 50%), #1a1a2e;
-		--header-bg: #1a1a2e;
-		--box-shadow:
-			0 2px 6px rgba(0, 0, 0, 40%), 0 8px 24px rgba(0, 0, 0, 50%),
-			0 16px 32px rgba(0, 0, 0, 50%);
-	}
-	body {
-		background-color: #1a1a2e;
-	}
-	code {
-		background-color: rgba(var(--gray-light), 80%);
-	}
+/* Dark mode (class-based, toggled via JS) */
+html.dark {
+	--accent: #7b8cff;
+	--accent-dark: #5b6bff;
+	--black: 229, 233, 240;
+	--gray: 160, 175, 210;
+	--gray-light: 50, 55, 70;
+	--gray-dark: 220, 225, 235;
+	--gray-gradient: rgba(var(--gray-light), 50%), #1a1a2e;
+	--header-bg: #1a1a2e;
+	--box-shadow:
+		0 2px 6px rgba(0, 0, 0, 40%), 0 8px 24px rgba(0, 0, 0, 50%),
+		0 16px 32px rgba(0, 0, 0, 50%);
+}
+html.dark body {
+	background-color: #1a1a2e;
+}
+html.dark code {
+	background-color: rgba(var(--gray-light), 80%);
 }
 
 body {
@@ -161,4 +159,11 @@ hr {
 	clip: rect(1px, 1px, 1px, 1px);
 	clip-path: inset(50%);
 	white-space: nowrap;
+}
+
+/* Smooth theme transition (disabled until page loads to prevent FOUC) */
+html.theme-ready,
+html.theme-ready body,
+html.theme-ready header {
+	transition: background-color 0.3s ease, color 0.3s ease;
 }


### PR DESCRIPTION
## Summary
Add a dark mode toggle button to the site header.

### Changes
- **ThemeToggle component** with sun/moon SVG icons
- **Toggle cycle**: system preference → light → dark → back to system
- **Anti-flash script** in both layouts (runs before paint)
- **localStorage persistence** so preference survives across visits
- **CSS converted** from media-query-based to class-based (`html.dark`)
- **Smooth transitions** enabled after page load via `theme-ready` class

### Testing
- `npm run build` passes
- No FOUC on load (inline script applies class before render)
- Toggle respects system preference when no stored preference exists

Closes #87